### PR TITLE
Optimise SVG Scaling in props.SvgCode

### DIFF
--- a/ScadaWeb/ScadaScheme/PlgSchShapeComp/plugins/SchShapeComp/js/shapecomprender.js
+++ b/ScadaWeb/ScadaScheme/PlgSchShapeComp/plugins/SchShapeComp/js/shapecomprender.js
@@ -197,9 +197,15 @@ scada.scheme.CustomSVGRenderer.prototype.createDom = function (
 		);
 		props.SvgCode = props.SvgCode.replace(
 			/<svg[^>]*?(\s+height\s*=\s*["'][^"']*["'])/g,
-			"<svg height='100%' width='100%'  preserveAspectRatio='none'",
+			"<svg",
 		);
+		props.SvgCode = props.SvgCode.replace(
+			/<svg/g,
+			"<svg height='100%' width='100%' preserveAspectRatio='none'"
+		);
+
 	}
+	
 	divComp.append(props.SvgCode);
 	component.dom = divComp;
 	


### PR DESCRIPTION

- Updated the SVG processing logic in props.SvgCode to ensure consistent scaling across different containers.
- Removed specific width and height attributes from SVG tags.
- Applied a uniform width and height (100%) to all SVG elements, overriding previous dimensions.
- Set preserveAspectRatio to 'none' to allow flexible resizing of SVGs without maintaining the aspect ratio.
